### PR TITLE
Upgrade to use Node.js 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3.5.1
         with:
-          node-version: "12.x"
+          node-version: 16
 
       - run: yarn install
 

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     description: The number of the issue or pull request.
     required: false
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: message-circle


### PR DESCRIPTION
## What this PR does / Why we need it
Usage of Node.js 12 is being deprecated by Github.

## Which issue(s) this PR fixes

Fixes #361
